### PR TITLE
Fix main manifest is not uploaded as public

### DIFF
--- a/apps/ffmpeg/outputs.py
+++ b/apps/ffmpeg/outputs.py
@@ -25,7 +25,7 @@ class Storage(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def save_data(self, content: str, path):
+    def save_text(self, content: str, path):
         pass
 
 
@@ -84,7 +84,7 @@ class S3(Storage):
                 absolute_file_path, s3_path.bucket_id, s3_path.key_id, ExtraArgs={"ACL": "public-read"}
             )
 
-    def save_data(self, content: str, path: str):
+    def save_text(self, content: str, path: str):
         s3_path = parse_uri(self.destination_url)
         file_obj = io.BytesIO(content.encode())
         self.client.upload_fileobj(file_obj, s3_path.bucket_id, s3_path.key_id, ExtraArgs={"ACL": "public-read"})
@@ -103,7 +103,7 @@ class FileStorage(Storage):
         shutil.move(source_directory, self.destination_directory)
         self.is_being_moved = False
 
-    def save_data(self, content, path):
+    def save_text(self, content, path):
         content_as_bytes = io.BytesIO(content.encode()).read()
         with open(self.destination_directory, "wb") as fout:
             fout.write(content_as_bytes)

--- a/apps/jobs/runnables.py
+++ b/apps/jobs/runnables.py
@@ -1,11 +1,7 @@
-import io
-
-from smart_open import open
-
 from django.shortcuts import get_object_or_404
 
 from apps.ffmpeg.main import Manager
-from apps.ffmpeg.input_options import InputOptionsFactory
+from apps.ffmpeg.outputs import OutputFactory
 from apps.jobs.models import Job, Output
 
 
@@ -104,10 +100,8 @@ class ManifestGeneratorRunnable(CeleryRunnable):
         return "#EXTM3U\n#EXT-X-VERSION:3\n"
 
     def upload(self):
-        file = io.BytesIO(self.manifest_content.encode()).read()
-        options = InputOptionsFactory.get(self.job.output_url).options
-        with open(self.job.output_url, "wb", transport_params=options) as fout:
-            fout.write(file)
+        storage = OutputFactory.create(self.job.output_url)
+        storage.save_data(self.manifest_content, self.job.output_url)
 
     def get_media_details(self):
         media_details = []

--- a/apps/jobs/runnables.py
+++ b/apps/jobs/runnables.py
@@ -101,7 +101,7 @@ class ManifestGeneratorRunnable(CeleryRunnable):
 
     def upload(self):
         storage = OutputFactory.create(self.job.output_url)
-        storage.save_data(self.manifest_content, self.job.output_url)
+        storage.save_text(self.manifest_content, self.job.output_url)
 
     def get_media_details(self):
         media_details = []


### PR DESCRIPTION
- We used `smart_open` to upload the manifest file. But it does not have an API to upload it as public.
- So we use the output factory to get appropriate storage which will upload it as public.