### PR TITLE
Fix manifest uploaded without end tag

### DIFF
--- a/lumberjack/apps/ffmpeg/event_source.py
+++ b/lumberjack/apps/ffmpeg/event_source.py
@@ -116,7 +116,8 @@ class EventSource(Observable):
         return log == "" and self.process.poll() is not None
 
     def notify_transcode_completed(self):
-        self.create_output_event(is_transcode_completed=True)
+        event = self.create_output_event(is_transcode_completed=True)
+        self.notify(event)
 
     def create_progress_event(self, percentage):
         return FFmpegEvent(FFmpegEvent.PROGRESS_EVENT, percentage)

--- a/lumberjack/tests/ffmpeg/test_monitor.py
+++ b/lumberjack/tests/ffmpeg/test_monitor.py
@@ -4,7 +4,7 @@ from apps.ffmpeg.event_source import EventSource, FFmpegEvent, Observer, Progres
 from .utils import ProcessMock
 
 
-class ProgressObserverMock(Observer):
+class ObserverMock(Observer):
     def __init__(self, event_type):
         self.called = False
         self.type = event_type
@@ -19,20 +19,20 @@ class ProgressObserverMock(Observer):
 
 class TestMonitor(SimpleTestCase):
     def test_observer_should_get_called_for_correct_event(self):
-        self.observer = ProgressObserverMock(FFmpegEvent.PROGRESS_EVENT)
+        self.observer = ObserverMock(FFmpegEvent.PROGRESS_EVENT)
         event_source = EventSource(ProcessMock())
         event_source.register(self.observer)
         event_source.run()
 
         self.assertTrue(self.observer.called)
 
-    def test_observer_should_not_get_called_for_incorrect_event(self):
-        self.observer = ProgressObserverMock(FFmpegEvent.OUTPUT_EVENT)
+    def test_output_event_should_get_triggered_once_log_is_finished(self):
+        self.output_event_observer = ObserverMock(FFmpegEvent.OUTPUT_EVENT)
         event_source = EventSource(ProcessMock())
-        event_source.register(self.observer)
+        event_source.register(self.output_event_observer)
         event_source.run()
 
-        self.assertFalse(self.observer.called)
+        self.assertTrue(self.output_event_observer.called)
 
 
 class TestProgressObserver(SimpleTestCase):


### PR DESCRIPTION
- If the transcoding percentage is 100, then we were uploading the manifest file. But the issue is 100% doesn't mean manifest is updated. It means that all video chunks are generated. End tag will be added to the manifest only after this.
- The solution is to upload the manifest once all the logs of FFmpeg are completed. 

No of test cases - Modified existing test case