### PR TITLE
Directly read input from protocol instead of piping input

### DIFF
--- a/lumberjack/apps/ffmpeg/command_generator.py
+++ b/lumberjack/apps/ffmpeg/command_generator.py
@@ -3,6 +3,7 @@ import binascii
 from django.conf import settings
 
 from apps.ffmpeg.utils import mkdir
+from .inputs import get_input_path
 
 
 class CommandGenerator(object):
@@ -29,7 +30,8 @@ class CommandGenerator(object):
 
     @property
     def input_argument(self):
-        return {"i": "-"}
+        path = self.options.get("input")
+        return {"i": get_input_path(path)}
 
     @property
     def local_path(self):

--- a/lumberjack/apps/ffmpeg/inputs.py
+++ b/lumberjack/apps/ffmpeg/inputs.py
@@ -1,0 +1,46 @@
+import abc
+
+from smart_open import parse_uri
+import boto3
+
+from django.conf import settings
+
+
+def get_input_path(path):
+    if path.startswith("http"):
+        return path
+
+    if path.startswith("s3://"):
+        return S3InputPath(path).generate()
+
+    return path
+
+
+class InputPath(abc.ABC):
+    def __init__(self, source):
+        self.source = source
+
+    @abc.abstractmethod
+    def generate(self):
+        pass
+
+
+class S3InputPath(InputPath):
+    def __init__(self, source):
+        super().__init__(source)
+        session = boto3.Session(
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+            region_name="ap-southeast-1",
+        )
+        self.client = session.client("s3")
+        self.source = source
+
+    def generate(self):
+        s3_path = parse_uri(self.source)
+        params = {
+            "Bucket": s3_path.bucket_id,
+            "Key": s3_path.key_id,
+        }
+        response = self.client.generate_presigned_url("get_object", Params=params, ExpiresIn=86400)
+        return response

--- a/lumberjack/apps/ffmpeg/main.py
+++ b/lumberjack/apps/ffmpeg/main.py
@@ -1,12 +1,9 @@
 import subprocess
 import shlex
 
-from smart_open import open
-
 from django.conf import settings
 
 from apps.ffmpeg.command_generator import CommandGenerator
-from apps.ffmpeg.input_options import InputOptionsFactory
 from apps.ffmpeg.utils import mkdir
 from apps.ffmpeg.event_source import EventSource, ProgressObserver, OutputObserver
 
@@ -49,14 +46,12 @@ class Executor:
     @property
     def options(self):
         return {
-            "stdin": subprocess.PIPE,
             "stdout": subprocess.PIPE,
             "stderr": subprocess.STDOUT,
             "universal_newlines": True,
         }
 
     def run(self):
-        self.read_input()
         self.process.wait()
         if self.process.returncode != 0:
             error = "\n".join(self.process.stdout.readlines())
@@ -65,12 +60,6 @@ class Executor:
 
     def start_process(self):
         self._process = subprocess.Popen(shlex.split(self.command), **self.options)
-
-    def read_input(self):
-        options = InputOptionsFactory.get(self.input)
-        for content in open(self.input, "rb", transport_params=options.__dict__):
-            self.process.stdin.buffer.write(content)
-        self.process.stdin.close()
 
     def stop_process(self):
         self._process.terminate()


### PR DESCRIPTION
- As FFmpeg already takes care of popular protocols for input we don't need to manually pipe and provide them as chunks.
- Issue in the manual input pipe is that videos with moov atom at the end won't get transcoded. This is because FFmpeg will check for moov atom in the input buffer but in our case moov atom will be at last and we will provide only 32 mb at a time. So FFmpeg will check for moov atom at first 32mb and when it is not found, it will stop transcoding.
- Fixes #12 