### PR TITLE
Fix error message not stored in job

### DIFF
--- a/lumberjack/apps/ffmpeg/event_source.py
+++ b/lumberjack/apps/ffmpeg/event_source.py
@@ -87,6 +87,7 @@ class EventSource(Observable):
         self.time = 0
         self.process = process
         self.thread = threading.Thread(target=self.run)
+        self.log = ""
 
     def run(self):
         while True:
@@ -102,6 +103,7 @@ class EventSource(Observable):
         while True:
             events = []
             log = self.process.stdout.readline().strip()
+            self.log += log
             if self.is_stdout_finished(log):
                 return False
 

--- a/lumberjack/apps/ffmpeg/main.py
+++ b/lumberjack/apps/ffmpeg/main.py
@@ -23,7 +23,10 @@ class Manager:
         self.event_source = EventSource(self.executor.process)
         self.register_observers()
         self.event_source.start()
-        self.executor.run()
+        try:
+            self.executor.run()
+        except FFMpegException as e:
+            raise FFMpegException(self.event_source.log)
 
     def create_observers(self):
         self.progress_observer = ProgressObserver(self.monitor)
@@ -54,8 +57,7 @@ class Executor:
     def run(self):
         self.process.wait()
         if self.process.returncode != 0:
-            error = "\n".join(self.process.stdout.readlines())
-            raise FFMpegException(error)
+            raise FFMpegException
         self.stop_process()
 
     def start_process(self):


### PR DESCRIPTION
- Previously we used to read error message from stdout in case transcoding is terminated due to some error. 
- But the issue is stdout is a stream so if data in it is read once it won't be available again. In our case, all stdout data will be read by a separate thread for progress.
- So error messages are not being stored in the job.
- Now the solution is we are storing all log in a variable and then in case of an error we will store that log in the job.