### PR TITLE
Fix FFmpeg process not killed when celery task is cancelled

### DIFF
--- a/lumberjack/apps/ffmpeg/main.py
+++ b/lumberjack/apps/ffmpeg/main.py
@@ -25,6 +25,9 @@ class Manager:
         self.event_source.start()
         self.executor.run()
 
+    def stop(self):
+        self.executor.stop_process()
+
     def create_observers(self):
         self.progress_observer = ProgressObserver(self.monitor)
         self.output_observer = OutputObserver(self.options.get("output")["url"], self.local_path)
@@ -55,6 +58,7 @@ class Executor:
         self.process.wait()
         if self.process.returncode != 0:
             error = "\n".join(self.process.stdout.readlines())
+            self.stop_process()
             raise FFMpegException(error)
         self.stop_process()
 

--- a/lumberjack/apps/jobs/managers.py
+++ b/lumberjack/apps/jobs/managers.py
@@ -73,7 +73,7 @@ class VideoTranscodeManager:
     def terminate_task(self):
         task = app.GroupResult.restore(str(self.job.background_task_id))
         if task:
-            task.revoke(terminate=True)
+            task.revoke(terminate=True, signal="SIGUSR1")
 
     def get_job_info(self):
         return self.job.job_info

--- a/lumberjack/apps/jobs/runnables.py
+++ b/lumberjack/apps/jobs/runnables.py
@@ -61,7 +61,7 @@ class VideoTranscoderRunnable(CeleryRunnable):
                 self.set_error_status_and_notify()
         except SoftTimeLimitExceeded:
             self.set_output_status_cancelled()
-            self.stop_process()
+            transcoder.stop()
 
     def initialize(self):
         self.job = Job.objects.get(id=self.job_id)
@@ -118,9 +118,6 @@ class VideoTranscoderRunnable(CeleryRunnable):
         self.job.status = Job.ERROR
         self.job.save()
         self.job.notify_webhook()
-
-    def stop_process(self):
-        self.ffmpeg_manager.stop()
 
 
 class ManifestGeneratorRunnable(CeleryRunnable):

--- a/lumberjack/apps/jobs/runnables.py
+++ b/lumberjack/apps/jobs/runnables.py
@@ -108,7 +108,7 @@ class VideoTranscoderRunnable(CeleryRunnable):
     def stop_job(self):
         group_tasks = app.GroupResult.restore(str(self.job.background_task_id))
         for task in group_tasks:
-            if task.id != self.task_id:
+            if task.id != self.task_id:  # Skip killing current task as it is going to be stopped anyway.
                 task.revoke(terminate=True, signal="SIGUSR1")
 
     def is_job_status_error(self):

--- a/lumberjack/apps/jobs/runnables.py
+++ b/lumberjack/apps/jobs/runnables.py
@@ -1,3 +1,5 @@
+from celery.exceptions import SoftTimeLimitExceeded
+
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
 
@@ -57,6 +59,9 @@ class VideoTranscoderRunnable(CeleryRunnable):
             self.stop_job()
             if not self.is_job_status_error():
                 self.set_error_status_and_notify()
+        except SoftTimeLimitExceeded:
+            self.set_output_status_cancelled()
+            self.stop_process()
 
     def initialize(self):
         self.job = Job.objects.get(id=self.job_id)
@@ -96,10 +101,15 @@ class VideoTranscoderRunnable(CeleryRunnable):
         self.output.error_message = error
         self.output.save()
 
+    def set_output_status_cancelled(self):
+        self.output.status = Output.CANCELLED
+        self.output.save()
+
     def stop_job(self):
-        task = app.GroupResult.restore(str(self.job.background_task_id))
-        if task:
-            task.revoke(terminate=True)
+        group_tasks = app.GroupResult.restore(str(self.job.background_task_id))
+        for task in group_tasks:
+            if task.id != self.task_id:
+                task.revoke(terminate=True, signal="SIGUSR1")
 
     def is_job_status_error(self):
         return Job.objects.get(id=self.job.id).status == Job.ERROR
@@ -108,6 +118,9 @@ class VideoTranscoderRunnable(CeleryRunnable):
         self.job.status = Job.ERROR
         self.job.save()
         self.job.notify_webhook()
+
+    def stop_process(self):
+        self.ffmpeg_manager.stop()
 
 
 class ManifestGeneratorRunnable(CeleryRunnable):

--- a/lumberjack/apps/jobs/tasks.py
+++ b/lumberjack/apps/jobs/tasks.py
@@ -12,7 +12,7 @@ class CeleryTask(Task):
     runnable = None
 
     def run(self, *args, **kwargs):
-        self.runnable(*args, **kwargs).run()
+        self.runnable(*args, **kwargs, task_id=self.request.id).run()
 
 
 class VideoTranscoder(CeleryTask):


### PR DESCRIPTION
- When a celery task is revoked, the FFmpeg process that is started by celery is not getting killed.
- This wastes resources as we don't need those cancelled FFmpeg processes to be running.
- By default, when we revoke celery task "SIGTERM" signal will be used. This will terminate celery task without performing any cleanup operation.
- We need to clean up the FFMpeg process once the celery task is killed. For this, we can use the "SIGUSR" signal. This is an user defined signal provided by linux. When we raise this signal, celery will raise `SoftTimeLimitExceeded` instead of terminating tasks.
- So we can do cleanup by handlng `SoftTimeLimitExceeded` exception.