### PR TITLE
Fix video transcoding is incomplete bug

### DIFF
--- a/lumberjack/apps/ffmpeg/command_generator.py
+++ b/lumberjack/apps/ffmpeg/command_generator.py
@@ -32,8 +32,14 @@ class CommandGenerator(object):
     @property
     def input_argument(self):
         path = self.options.get("input")
+        FIVE_MINUTES = 300
         return OrderedDict(
-            [("reconnect", 1), ("reconnect_streamed", 1), ("reconnect_delay_max", 300), ("i", get_input_path(path))]
+            [
+                ("reconnect", 1),
+                ("reconnect_streamed", 1),
+                ("reconnect_delay_max", FIVE_MINUTES),
+                ("i", get_input_path(path)),
+            ]
         )
 
     @property

--- a/lumberjack/apps/ffmpeg/command_generator.py
+++ b/lumberjack/apps/ffmpeg/command_generator.py
@@ -1,4 +1,5 @@
 import binascii
+from collections import OrderedDict
 
 from django.conf import settings
 
@@ -31,7 +32,9 @@ class CommandGenerator(object):
     @property
     def input_argument(self):
         path = self.options.get("input")
-        return {"i": get_input_path(path)}
+        return OrderedDict(
+            [("reconnect", 1), ("reconnect_streamed", 1), ("reconnect_delay_max", 300), ("i", get_input_path(path))]
+        )
 
     @property
     def local_path(self):


### PR DESCRIPTION
- In case of a network error, FFmpeg finishes transcoding. This leads to an incomplete transcoded video.
- So we added support to reconnect in case of a network error.
- We have added 5 min network reconnect time.