### PR TITLE
Expose transcoding details in job info API

### DIFF
--- a/lumberjack/apps/jobs/models.py
+++ b/lumberjack/apps/jobs/models.py
@@ -53,12 +53,20 @@ class Job(TimeStampedModel, TimeFramedModel, JobNotifierMixin):
 
     @property
     def job_info(self):
+        transcoding_duration = None
+        if self.start and self.end:
+            transcoding_duration = self.end - self.start
+
         return {
             "id": self.id,
             "status": self.get_status_display(),
             "settings": self.settings,
             "input_url": self.input_url,
             "output_url": self.output_url,
+            "start_time": self.start,
+            "end_time": self.end,
+            "transcoding_duration": transcoding_duration,
+            "submission_time": self.created,
         }
 
     def populate_settings(self):

--- a/lumberjack/tests/api/v1/jobs/test_views.py
+++ b/lumberjack/tests/api/v1/jobs/test_views.py
@@ -1,8 +1,10 @@
 import json
 import mock
 import uuid
+from datetime import timedelta
 
 from django.test import RequestFactory, TestCase
+from django.utils.timezone import now
 
 from apps.api.v1.jobs.views import CreateJobView, job_info_view, cancel_job_view, restart_job_view
 from apps.jobs.models import Job
@@ -62,6 +64,9 @@ class TestCreateJobView(TestCase, Mixin, JobMixin):
 class TestJobInfoView(TestCase, JobMixin):
     def setUp(self):
         self.factory = RequestFactory()
+        self.job.start = now()
+        self.job.end = now() + timedelta(days=1)
+        self.job.save()
 
     def test_api_should_return_job_info_for_job(self):
         request = self.factory.get("/api/v1/jobs/%s" % self.job.id)
@@ -75,6 +80,15 @@ class TestJobInfoView(TestCase, JobMixin):
         response = job_info_view(request, uuid.uuid4())
 
         self.assertEqual(404, response.status_code)
+
+    def test_api_should_have_transcoding_details(self):
+        request = self.factory.get("/api/v1/jobs/%s" % self.job.id)
+        response = job_info_view(request, self.job.id)
+
+        self.assertEqual(response.data["start_time"], self.job.start)
+        self.assertEqual(response.data["end_time"], self.job.end)
+        self.assertEqual(response.data["submission_time"], self.job.created)
+        self.assertEqual(response.data["transcoding_duration"], self.job.end - self.job.start)
 
 
 class TestCancelJobView(TestCase, JobMixin):


### PR DESCRIPTION
- Exposed transcoding details like submission time, start time, end time in job info API


No of test case - 1