### PR TITLE
Remove celery chord and use celery group

### DIFF
--- a/lumberjack/apps/jobs/managers.py
+++ b/lumberjack/apps/jobs/managers.py
@@ -24,10 +24,7 @@ class VideoTranscoder:
 
     def start_tasks(self, tasks):
         task = group(tasks).apply_async()
-        task.save()
-        self.job.background_task_id = task.id
-        self.job.status = Job.QUEUED
-        self.job.save()
+        self.save_background_task_to_job(task)
 
     def create_outputs(self):
         job_settings = copy.deepcopy(self.job.settings)
@@ -51,6 +48,11 @@ class VideoTranscoder:
             output.save()
             outputs.append(output)
         return outputs
+
+    def save_background_task_to_job(self, task):
+        task.save()
+        self.job.background_task_id = task.id
+        self.update_job_status(Job.QUEUED)
 
     def get_output_folder_path(self, output_settings):
         return self.job.settings["destination"] + "/" + output_settings["name"]

--- a/lumberjack/apps/jobs/managers.py
+++ b/lumberjack/apps/jobs/managers.py
@@ -49,11 +49,6 @@ class VideoTranscoder:
             outputs.append(output)
         return outputs
 
-    def save_background_task_to_job(self, task):
-        task.save()
-        self.job.background_task_id = task.id
-        self.update_job_status(Job.QUEUED)
-
     def get_output_folder_path(self, output_settings):
         return self.job.settings["destination"] + "/" + output_settings["name"]
 
@@ -65,6 +60,11 @@ class VideoTranscoder:
                 for output in outputs
             ]
         return [VideoTranscoderTask.s(job_id=self.job.id, output_id=output.id) for output in outputs]
+
+    def save_background_task_to_job(self, task):
+        task.save()
+        self.job.background_task_id = task.id
+        self.update_job_status(Job.QUEUED)
 
     def update_job_status(self, status):
         self.job.status = status

--- a/lumberjack/apps/jobs/managers.py
+++ b/lumberjack/apps/jobs/managers.py
@@ -24,7 +24,10 @@ class VideoTranscoder:
 
     def start_tasks(self, tasks):
         task = group(tasks).apply_async()
-        self.save_background_task_to_job(task)
+        task.save()
+        self.job.background_task_id = task.id
+        self.job.status = Job.QUEUED
+        self.job.save()
 
     def create_outputs(self):
         job_settings = copy.deepcopy(self.job.settings)
@@ -60,11 +63,6 @@ class VideoTranscoder:
                 for output in outputs
             ]
         return [VideoTranscoderTask.s(job_id=self.job.id, output_id=output.id) for output in outputs]
-
-    def save_background_task_to_job(self, task):
-        task.save()
-        self.job.background_task_id = task.id
-        self.update_job_status(Job.QUEUED)
 
     def update_job_status(self, status):
         self.job.status = status

--- a/lumberjack/apps/jobs/runnables.py
+++ b/lumberjack/apps/jobs/runnables.py
@@ -68,6 +68,7 @@ class VideoTranscoderRunnable(LumberjackRunnable):
             if self.is_transcoding_completed():
                 self.complete_job()
                 self.notify_webhook()
+                self.generate_manifest()
 
     def initialize(self):
         self.job = Job.objects.get(id=self.job_id)
@@ -110,6 +111,9 @@ class VideoTranscoderRunnable(LumberjackRunnable):
 
     def is_multiple_of_five(self, percentage):
         return (percentage % 5) == 0 and self.output.progress != percentage
+
+    def generate_manifest(self):
+        ManifestGeneratorRunnable(job_id=self.job.id).run()
 
     def update_progress(self, percentage):
         if self.is_multiple_of_five(percentage):

--- a/lumberjack/apps/jobs/runnables.py
+++ b/lumberjack/apps/jobs/runnables.py
@@ -2,6 +2,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 
 from django.shortcuts import get_object_or_404
 from django.utils.timezone import now
+from django.db import transaction
 
 from lumberjack.celery import app
 from apps.ffmpeg.main import Manager, FFMpegException
@@ -63,6 +64,11 @@ class VideoTranscoderRunnable(LumberjackRunnable):
             self.set_output_status_cancelled()
             transcoder.stop()
 
+        with transaction.atomic():
+            if self.is_transcoding_completed():
+                self.complete_job()
+                self.notify_webhook()
+
     def initialize(self):
         self.job = Job.objects.get(id=self.job_id)
         self.output = Output.objects.get(id=self.output_id)
@@ -74,6 +80,20 @@ class VideoTranscoderRunnable(LumberjackRunnable):
         self.job.status = Job.PROCESSING
         self.job.start = now()
         self.job.save()
+
+    def is_transcoding_completed(self):
+        return not self.job.outputs.exclude(status=Output.COMPLETED).exists()
+
+    def complete_job(self):
+        job = Job.objects.select_for_update().get(id=self.job.id)
+        if job.status is not Job.COMPLETED:
+            job.status = Job.COMPLETED
+            job.end = now()
+            job.save(update_fields=["status", "end"])
+
+    def notify_webhook(self):
+        self.job.refresh_from_db()
+        self.job.notify_webhook()
 
     def update_output_status_and_time(self, status, start=None, end=None):
         if start:
@@ -125,8 +145,6 @@ class ManifestGeneratorRunnable(LumberjackRunnable):
         self.initialize()
         self.generate_manifest_content()
         self.upload()
-        self.complete_job()
-        self.notify_webhook()
 
     def initialize(self):
         self.job = get_object_or_404(Job, id=self.job_id)
@@ -159,12 +177,3 @@ class ManifestGeneratorRunnable(LumberjackRunnable):
                 f"RESOLUTION={media_detail['resolution']}\n{media_detail['name']}\n\n"
             )
         self.manifest_content = content
-
-    def complete_job(self):
-        self.job.status = Job.COMPLETED
-        self.job.end = now()
-        self.job.save(update_fields=["status", "end"])
-
-    def notify_webhook(self):
-        self.job.refresh_from_db()
-        self.job.notify_webhook()

--- a/lumberjack/tests/jobs/test_managers.py
+++ b/lumberjack/tests/jobs/test_managers.py
@@ -33,17 +33,17 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         self.job = self.create_job(settings=self.job_settings)
         self.manager = VideoTranscoder(self.job)
 
-    @mock.patch("apps.jobs.managers.chord")
-    def test_start_should_start_background_task(self, mock_celery_chord):
-        mock_celery_chord.return_value.return_value.parent.id = 12
+    @mock.patch("apps.jobs.managers.group")
+    def test_start_should_start_background_task(self, mock_celery_group):
+        mock_celery_group.return_value.apply_async().id = 12
         self.manager.start()
 
-        mock_celery_chord.assert_called()
+        mock_celery_group.return_value.apply_async.assert_called()
         self.assertEqual(12, self.job.background_task_id)
 
-    @mock.patch("apps.jobs.managers.chord")
-    def test_start_should_create_outputs_for_job(self, mock_celery_chord):
-        mock_celery_chord.return_value.return_value.parent.id = 12
+    @mock.patch("apps.jobs.managers.group")
+    def test_start_should_create_outputs_for_job(self, mock_celery_group):
+        mock_celery_group.return_value.apply_async().id = 12
         self.manager.start()
 
         self.assertEqual(1, self.job.outputs.count())
@@ -56,14 +56,14 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         self.assertEqual(Job.CANCELLED, self.job.status)
         mock_group_result.restore().revoke.assert_called()
 
-    @mock.patch("apps.jobs.managers.chord")
+    @mock.patch("apps.jobs.managers.group")
     @mock.patch("apps.jobs.managers.app.GroupResult")
-    def test_restart_job_should_stop_running_task_and_start_again(self, mock_group_result, mock_celery_chord):
-        mock_celery_chord.return_value.return_value.parent.id = 12
+    def test_restart_job_should_stop_running_task_and_start_again(self, mock_group_result, mock_celery_group):
+        mock_celery_group.return_value.apply_async().id = 12
         self.manager.restart()
 
         mock_group_result.restore().revoke.assert_called()
-        mock_celery_chord.assert_called()
+        mock_celery_group.return_value.apply_async.assert_called()
         self.assertEqual(12, self.job.background_task_id)
 
     def test_outputs_should_run_in_specific_queue_if_provided_in_job_meta(self):

--- a/lumberjack/tests/jobs/test_tasks.py
+++ b/lumberjack/tests/jobs/test_tasks.py
@@ -105,7 +105,7 @@ class TestVideoTranscoder(Mixin, TestCase):
 
         self.job.refresh_from_db()
         self.assertEqual(self.job.status, Job.COMPLETED)
-        mock_webhook.apply_async.assert_called_with(args=(self.job.job_info, "google.com"))
+        mock_webhook.apply_async.assert_called_with(args=(JobSerializer(instance=self.job).data, "google.com"))
 
     @mock.patch("apps.jobs.runnables.ManifestGeneratorRunnable")
     @mock.patch("apps.jobs.runnables.Manager")

--- a/lumberjack/tests/jobs/test_tasks.py
+++ b/lumberjack/tests/jobs/test_tasks.py
@@ -107,6 +107,15 @@ class TestVideoTranscoder(Mixin, TestCase):
         self.assertEqual(self.job.status, Job.COMPLETED)
         mock_webhook.apply_async.assert_called_with(args=(self.job.job_info, "google.com"))
 
+    @mock.patch("apps.jobs.runnables.ManifestGeneratorRunnable")
+    @mock.patch("apps.jobs.runnables.Manager")
+    def test_manifest_generator_should_be_called_on_transcoding_completion(
+        self, mock_ffmpeg_manager, mock_manifest_generator
+    ):
+        self.video_transcoder.do_run()
+
+        mock_manifest_generator.assert_called()
+
 
 class TestManifestGenerator(Mixin, TestCase):
     def setUp(self) -> None:

--- a/lumberjack/tests/jobs/test_tasks.py
+++ b/lumberjack/tests/jobs/test_tasks.py
@@ -88,6 +88,25 @@ class TestVideoTranscoder(Mixin, TestCase):
         self.assertEqual(self.video_transcoder.output.status, Output.CANCELLED)
         mock_ffmpeg_manager().stop.assert_called()
 
+    def test_complete_job_should_change_status_to_completed(self):
+        self.video_transcoder.complete_job()
+
+        self.job.refresh_from_db()
+        self.assertEqual(self.job.status, Job.COMPLETED)
+
+    @mock.patch("apps.jobs.tasks.PostDataToWebhookTask")
+    @mock.patch("apps.jobs.runnables.Manager")
+    def test_job_completion_status_should_should_be_notified_on_transcoding_completion(
+        self, mock_ffmpeg, mock_webhook
+    ):
+        self.job.webhook_url = "google.com"
+        self.job.save()
+        self.video_transcoder.do_run()
+
+        self.job.refresh_from_db()
+        self.assertEqual(self.job.status, Job.COMPLETED)
+        mock_webhook.apply_async.assert_called_with(args=(self.job.job_info, "google.com"))
+
 
 class TestManifestGenerator(Mixin, TestCase):
     def setUp(self) -> None:
@@ -113,11 +132,6 @@ class TestManifestGenerator(Mixin, TestCase):
             "RESOLUTION=1280x720\n720p/video.m3u8\n\n"
         )
         self.assertEqual(expected_manifest_content, self.manifest_generator.manifest_content)
-
-    def update_job_status_should_update_job_as_completed(self):
-        self.manifest_generator.complete_job()
-
-        self.assertEqual(Job.COMPLETED, self.job.status)
 
     def test_upload(self):
         self.start_s3_mock()


### PR DESCRIPTION
- We used celery chord to generate manifest after all resolutions are transcoded.
- But sometimes manifest generation happens before videos are transcoded, so instead of using celery chord we are using group to run transcoding tasks in parallel.
- Whenever each transcoding is completed we will check if other transcodings are also completed, it all transcodings for that job is completed then manifest will be generated.

No of test cases - 2