### PR TITLE
Add support to transcode to fragmented mp4

### DIFF
--- a/lumberjack/apps/ffmpeg/utils.py
+++ b/lumberjack/apps/ffmpeg/utils.py
@@ -7,3 +7,13 @@ def mkdir(dirname: str) -> None:
         os.makedirs(dirname)
     except OSError as exc:
         logging.info(exc)
+
+
+class ExtensionGenerator:
+    def get(self, file_type):
+        if file_type.lower() == "mp4":
+            return "mp4"
+        elif file_type.lower() == "hls":
+            return "m3u8"
+        elif file_type.lower() == "dash":
+            return "mpd"

--- a/lumberjack/tests/ffmpeg/test_command_generator.py
+++ b/lumberjack/tests/ffmpeg/test_command_generator.py
@@ -75,6 +75,21 @@ class TestCommandGenerator(SimpleTestCase):
         output_path = "tests/ffmpeg/data/1232/360p/video.m3u8"
         self.assertEqual(output_path, self.command_generator.output_path)
 
+    def test_output_path_file_name_should_have_extension_if_not_provided_by_user(self):
+        data = self.data
+        data["format"] = "MP4"
+        data["file_name"] = "video"
+        command_generator = CommandGenerator(data)
+
+        self.assertTrue(command_generator.output_path.endswith(".mp4"))
+
+    def test_command_for_mp4_should_have_fragmentation_flags(self):
+        data = self.data
+        data["format"] = "MP4"
+        command_generator = CommandGenerator(data)
+
+        self.assertEqual("frag_keyframe+empty_moov", command_generator.media_options["movflags"])
+
 
 class TestHLSKeyInfoFile(SimpleTestCase):
     def setUp(self) -> None:

--- a/lumberjack/tests/ffmpeg/test_utils.py
+++ b/lumberjack/tests/ffmpeg/test_utils.py
@@ -1,0 +1,19 @@
+from django.test import SimpleTestCase
+from apps.ffmpeg.utils import ExtensionGenerator
+
+
+class TestExtensionGenerator(SimpleTestCase):
+    def test_mp4_should_be_returned_for_mp4_type(self):
+        extension = ExtensionGenerator().get("MP4")
+
+        self.assertEqual("mp4", extension)
+
+    def test_m3u8_should_be_returned_for_hls(self):
+        extension = ExtensionGenerator().get("HLS")
+
+        self.assertEqual("m3u8", extension)
+
+    def test_m3u8_should_be_returned_for_dash(self):
+        extension = ExtensionGenerator().get("DASH")
+
+        self.assertEqual("mpd", extension)


### PR DESCRIPTION
- Added mov flags(to fragment MP4) to the FFMpeg command generation for MP4 format.
- Extension will be autogenerated if not provided in the output path 


No of test cases - 5