### PR TITLE
Remove celery group and use individual task

### DIFF
--- a/lumberjack/apps/jobs/managers.py
+++ b/lumberjack/apps/jobs/managers.py
@@ -1,39 +1,14 @@
-import json
-
-from apps.jobs.models import Job
-from lumberjack.celery import app
-
-
 class VideoTranscoder:
     def __init__(self, job):
         self.job = job
 
     def start(self, sync=False):
         self.job.create_outputs()
-        self.start_tasks(sync)
+        self.job.start_trascoding(sync)
 
     def restart(self, sync=False):
-        self.stop()
-        self.start_tasks(sync)
-
-    def start_tasks(self, sync=False):
-        self.update_job_status(Job.QUEUED)
-        queue = "transcoding"
-        if self.job.meta_data and json.loads(self.job.meta_data).get("queue"):
-            meta_data = json.loads(self.job.meta_data)
-            queue = meta_data.get("queue", queue)
-
-        for output in self.job.outputs.all():
-            output.start_task(queue, sync)
-
-    def update_job_status(self, status):
-        self.job.status = status
-        self.job.save()
+        self.job.stop()
+        self.job.start_trascoding(sync)
 
     def stop(self):
-        if self.job.status == Job.COMPLETED:
-            return
-
-        for output in self.job.outputs.all():
-            app.control.revoke(output.background_task_id, terminate=True, signal="SIGUSR1")
-        self.update_job_status(Job.CANCELLED)
+        self.job.stop()

--- a/lumberjack/apps/jobs/managers.py
+++ b/lumberjack/apps/jobs/managers.py
@@ -4,11 +4,11 @@ class VideoTranscoder:
 
     def start(self, sync=False):
         self.job.create_outputs()
-        self.job.start_trascoding(sync)
+        self.job.start_transcoding(sync)
 
     def restart(self, sync=False):
         self.job.stop()
-        self.job.start_trascoding(sync)
+        self.job.start_transcoding(sync)
 
     def stop(self):
         self.job.stop()

--- a/lumberjack/apps/jobs/managers.py
+++ b/lumberjack/apps/jobs/managers.py
@@ -2,13 +2,13 @@ class VideoTranscoder:
     def __init__(self, job):
         self.job = job
 
-    def start(self, sync=False):
+    def start(self, sync=False, queue="transcoding"):
         self.job.create_outputs()
-        self.job.start(sync)
+        self.job.start(sync, queue)
 
-    def restart(self, sync=False):
+    def restart(self, sync=False, queue="transcoding"):
         self.job.stop()
-        self.job.start(sync)
+        self.job.start(sync, queue)
 
     def stop(self):
         self.job.stop()

--- a/lumberjack/apps/jobs/managers.py
+++ b/lumberjack/apps/jobs/managers.py
@@ -4,11 +4,11 @@ class VideoTranscoder:
 
     def start(self, sync=False):
         self.job.create_outputs()
-        self.job.start_transcoding(sync)
+        self.job.start(sync)
 
     def restart(self, sync=False):
         self.job.stop()
-        self.job.start_transcoding(sync)
+        self.job.start(sync)
 
     def stop(self):
         self.job.stop()

--- a/lumberjack/apps/jobs/models.py
+++ b/lumberjack/apps/jobs/models.py
@@ -97,7 +97,7 @@ class Job(TimeStampedModel, JobNotifierMixin):
 
         self.settings = settings
 
-    def start_trascoding(self, sync=False):
+    def start_transcoding(self, sync=False):
         self.status = Job.QUEUED
         self.save()
 

--- a/lumberjack/apps/jobs/models.py
+++ b/lumberjack/apps/jobs/models.py
@@ -151,6 +151,16 @@ class Output(AbstractOutput):
     def resolution(self):
         return f"{self.width}x{self.height}"
 
+    def start_task(self, queue, sync=False):
+        from .tasks import VideoTranscoderTask
+
+        if sync:
+            task = VideoTranscoderTask.apply(kwargs={"job_id": self.job.id, "output_id": self.id})
+        else:
+            task = VideoTranscoderTask.apply_async(kwargs={"job_id": self.job.id, "output_id": self.id}, queue=queue)
+        self.background_task_id = task.task_id
+        self.save()
+
     def __str__(self):
         if self.status == self.PROCESSING:
             return f"{self.name} - {self.job_id} - {self.progress}% Transcoded"

--- a/lumberjack/tests/jobs/test_managers.py
+++ b/lumberjack/tests/jobs/test_managers.py
@@ -76,22 +76,8 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         self.assertEqual("4c1761d8-c0cd-4068-a997-ccab60592943", str(self.job.outputs.first().background_task_id))
 
     @mock.patch("apps.jobs.tasks.VideoTranscoderTask")
-    def test_outputs_should_run_in_specific_queue_if_provided_in_job_meta(self, mock_celery_task):
+    def test_outputs_should_not_have_queue_if_not_provided(self, mock_celery_task):
         mock_celery_task.apply_async().task_id = 12
-        self.job.meta_data = json.dumps({"queue": "priority"})
-        self.job.save()
-        self.create_output(job=self.job)
-        self.manager.start()
-
-        mock_celery_task.apply_async.assert_called_with(
-            kwargs={"job_id": self.job.id, "output_id": self.job.outputs.last().id}, queue="priority"
-        )
-
-    @mock.patch("apps.jobs.tasks.VideoTranscoderTask")
-    def test_outputs_should_not_have_queue_if_not_provided_in_job_meta(self, mock_celery_task):
-        mock_celery_task.apply_async().task_id = 12
-        self.job.meta_data = None
-        self.job.save()
         self.create_output(job=self.job)
         self.manager.start()
 

--- a/lumberjack/tests/jobs/test_managers.py
+++ b/lumberjack/tests/jobs/test_managers.py
@@ -75,18 +75,26 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         mock_celery_task.apply_async.assert_called()
         self.assertEqual("4c1761d8-c0cd-4068-a997-ccab60592943", str(self.job.outputs.first().background_task_id))
 
-    def test_outputs_should_run_in_specific_queue_if_provided_in_job_meta(self):
+    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
+    def test_outputs_should_run_in_specific_queue_if_provided_in_job_meta(self, mock_celery_task):
+        mock_celery_task.apply_async().task_id = 12
         self.job.meta_data = json.dumps({"queue": "priority"})
         self.job.save()
         self.create_output(job=self.job)
-        tasks = self.manager.create_output_tasks(self.job.outputs.all())
+        self.manager.start_tasks()
 
-        self.assertEqual("priority", tasks[0].options.get("queue"))
+        mock_celery_task.apply_async.assert_called_with(
+            kwargs={"job_id": self.job.id, "output_id": self.job.outputs.last().id}, queue="priority"
+        )
 
-    def test_outputs_should_not_have_queue_if_not_provided_in_job_meta(self):
+    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
+    def test_outputs_should_not_have_queue_if_not_provided_in_job_meta(self, mock_celery_task):
+        mock_celery_task.apply_async().task_id = 12
         self.job.meta_data = None
         self.job.save()
         self.create_output(job=self.job)
-        tasks = self.manager.create_output_tasks(self.job.outputs.all())
+        self.manager.start_tasks()
 
-        self.assertEqual(None, tasks[0].options.get("queue"))
+        mock_celery_task.apply_async.assert_called_with(
+            kwargs={"job_id": self.job.id, "output_id": self.job.outputs.last().id}, queue="transcoding"
+        )

--- a/lumberjack/tests/jobs/test_managers.py
+++ b/lumberjack/tests/jobs/test_managers.py
@@ -34,7 +34,7 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         self.create_output(self.job)
         self.manager = VideoTranscoder(self.job)
 
-    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
+    @mock.patch("apps.jobs.tasks.VideoTranscoderTask")
     def test_start_should_start_background_task(self, mock_celery_task):
         mock_celery_task.apply_async().task_id = "4c1761d8-c0cd-4068-a997-ccab60592943"
         self.manager.start()
@@ -42,7 +42,7 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         mock_celery_task.apply_async.assert_called()
         self.assertEqual("4c1761d8-c0cd-4068-a997-ccab60592943", str(self.job.outputs.first().background_task_id))
 
-    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
+    @mock.patch("apps.jobs.tasks.VideoTranscoderTask")
     def test_start_should_create_outputs_for_job(self, mock_celery_task):
         mock_celery_task.apply_async().task_id = 12
         self.manager.start()
@@ -50,7 +50,7 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         self.assertEqual(2, self.job.outputs.count())
         self.assertEqual(Output.objects.filter(job_id=self.job.id).first(), self.job.outputs.first())
 
-    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
+    @mock.patch("apps.jobs.tasks.VideoTranscoderTask")
     def test_start_with_sync_should_should_run_synchronously(self, mock_celery_task):
         mock_celery_task.apply().task_id = 12
         self.manager.start(sync=True)
@@ -65,7 +65,7 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         self.assertEqual(Job.CANCELLED, self.job.status)
         mock_celery_control.revoke.assert_called()
 
-    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
+    @mock.patch("apps.jobs.tasks.VideoTranscoderTask")
     @mock.patch("apps.jobs.managers.app.control")
     def test_restart_job_should_stop_running_task_and_start_again(self, mock_celery_control, mock_celery_task):
         mock_celery_task.apply_async().task_id = "4c1761d8-c0cd-4068-a997-ccab60592943"
@@ -75,7 +75,7 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         mock_celery_task.apply_async.assert_called()
         self.assertEqual("4c1761d8-c0cd-4068-a997-ccab60592943", str(self.job.outputs.first().background_task_id))
 
-    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
+    @mock.patch("apps.jobs.tasks.VideoTranscoderTask")
     def test_outputs_should_run_in_specific_queue_if_provided_in_job_meta(self, mock_celery_task):
         mock_celery_task.apply_async().task_id = 12
         self.job.meta_data = json.dumps({"queue": "priority"})
@@ -87,7 +87,7 @@ class TestVideoTranscodeManager(TestCase, Mixin):
             kwargs={"job_id": self.job.id, "output_id": self.job.outputs.last().id}, queue="priority"
         )
 
-    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
+    @mock.patch("apps.jobs.tasks.VideoTranscoderTask")
     def test_outputs_should_not_have_queue_if_not_provided_in_job_meta(self, mock_celery_task):
         mock_celery_task.apply_async().task_id = 12
         self.job.meta_data = None

--- a/lumberjack/tests/jobs/test_managers.py
+++ b/lumberjack/tests/jobs/test_managers.py
@@ -31,48 +31,49 @@ class TestVideoTranscodeManager(TestCase, Mixin):
 
     def setUp(self) -> None:
         self.job = self.create_job(settings=self.job_settings)
+        self.create_output(self.job)
         self.manager = VideoTranscoder(self.job)
 
-    @mock.patch("apps.jobs.managers.group")
+    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
     def test_start_should_start_background_task(self, mock_celery_group):
-        mock_celery_group.return_value.apply_async().id = 12
+        mock_celery_group.apply_async().task_id = "4c1761d8-c0cd-4068-a997-ccab60592943"
         self.manager.start()
 
-        mock_celery_group.return_value.apply_async.assert_called()
-        self.assertEqual(12, self.job.background_task_id)
+        mock_celery_group.apply_async.assert_called()
+        self.assertEqual("4c1761d8-c0cd-4068-a997-ccab60592943", str(self.job.outputs.first().background_task_id))
 
-    @mock.patch("apps.jobs.managers.group")
+    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
     def test_start_should_create_outputs_for_job(self, mock_celery_group):
-        mock_celery_group.return_value.apply_async().id = 12
+        mock_celery_group.apply_async().task_id = 12
         self.manager.start()
 
-        self.assertEqual(1, self.job.outputs.count())
+        self.assertEqual(2, self.job.outputs.count())
         self.assertEqual(Output.objects.filter(job_id=self.job.id).first(), self.job.outputs.first())
 
-    @mock.patch("apps.jobs.managers.group")
+    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
     def test_start_with_sync_should_should_run_synchronously(self, mock_celery_group):
-        mock_celery_group.return_value.apply().id = 12
+        mock_celery_group.apply().task_id = 12
         self.manager.start(sync=True)
 
-        self.assertEqual(1, self.job.outputs.count())
+        self.assertEqual(2, self.job.outputs.count())
         self.assertEqual(Output.objects.filter(job_id=self.job.id).first(), self.job.outputs.first())
 
-    @mock.patch("apps.jobs.managers.app.GroupResult")
-    def test_stop_should_revoke_background_task(self, mock_group_result):
+    @mock.patch("apps.jobs.managers.app.control")
+    def test_stop_should_revoke_background_task(self, mock_celery_control):
         self.manager.stop()
 
         self.assertEqual(Job.CANCELLED, self.job.status)
-        mock_group_result.restore().revoke.assert_called()
+        mock_celery_control.revoke.assert_called()
 
-    @mock.patch("apps.jobs.managers.group")
-    @mock.patch("apps.jobs.managers.app.GroupResult")
-    def test_restart_job_should_stop_running_task_and_start_again(self, mock_group_result, mock_celery_group):
-        mock_celery_group.return_value.apply_async().id = 12
+    @mock.patch("apps.jobs.managers.VideoTranscoderTask")
+    @mock.patch("apps.jobs.managers.app.control")
+    def test_restart_job_should_stop_running_task_and_start_again(self, mock_celery_control, mock_celery_group):
+        mock_celery_group.apply_async().task_id = "4c1761d8-c0cd-4068-a997-ccab60592943"
         self.manager.restart()
 
-        mock_group_result.restore().revoke.assert_called()
-        mock_celery_group.return_value.apply_async.assert_called()
-        self.assertEqual(12, self.job.background_task_id)
+        mock_celery_control.revoke.assert_called()
+        mock_celery_group.apply_async.assert_called()
+        self.assertEqual("4c1761d8-c0cd-4068-a997-ccab60592943", str(self.job.outputs.first().background_task_id))
 
     def test_outputs_should_run_in_specific_queue_if_provided_in_job_meta(self):
         self.job.meta_data = json.dumps({"queue": "priority"})

--- a/lumberjack/tests/jobs/test_managers.py
+++ b/lumberjack/tests/jobs/test_managers.py
@@ -35,24 +35,24 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         self.manager = VideoTranscoder(self.job)
 
     @mock.patch("apps.jobs.managers.VideoTranscoderTask")
-    def test_start_should_start_background_task(self, mock_celery_group):
-        mock_celery_group.apply_async().task_id = "4c1761d8-c0cd-4068-a997-ccab60592943"
+    def test_start_should_start_background_task(self, mock_celery_task):
+        mock_celery_task.apply_async().task_id = "4c1761d8-c0cd-4068-a997-ccab60592943"
         self.manager.start()
 
-        mock_celery_group.apply_async.assert_called()
+        mock_celery_task.apply_async.assert_called()
         self.assertEqual("4c1761d8-c0cd-4068-a997-ccab60592943", str(self.job.outputs.first().background_task_id))
 
     @mock.patch("apps.jobs.managers.VideoTranscoderTask")
-    def test_start_should_create_outputs_for_job(self, mock_celery_group):
-        mock_celery_group.apply_async().task_id = 12
+    def test_start_should_create_outputs_for_job(self, mock_celery_task):
+        mock_celery_task.apply_async().task_id = 12
         self.manager.start()
 
         self.assertEqual(2, self.job.outputs.count())
         self.assertEqual(Output.objects.filter(job_id=self.job.id).first(), self.job.outputs.first())
 
     @mock.patch("apps.jobs.managers.VideoTranscoderTask")
-    def test_start_with_sync_should_should_run_synchronously(self, mock_celery_group):
-        mock_celery_group.apply().task_id = 12
+    def test_start_with_sync_should_should_run_synchronously(self, mock_celery_task):
+        mock_celery_task.apply().task_id = 12
         self.manager.start(sync=True)
 
         self.assertEqual(2, self.job.outputs.count())
@@ -67,12 +67,12 @@ class TestVideoTranscodeManager(TestCase, Mixin):
 
     @mock.patch("apps.jobs.managers.VideoTranscoderTask")
     @mock.patch("apps.jobs.managers.app.control")
-    def test_restart_job_should_stop_running_task_and_start_again(self, mock_celery_control, mock_celery_group):
-        mock_celery_group.apply_async().task_id = "4c1761d8-c0cd-4068-a997-ccab60592943"
+    def test_restart_job_should_stop_running_task_and_start_again(self, mock_celery_control, mock_celery_task):
+        mock_celery_task.apply_async().task_id = "4c1761d8-c0cd-4068-a997-ccab60592943"
         self.manager.restart()
 
         mock_celery_control.revoke.assert_called()
-        mock_celery_group.apply_async.assert_called()
+        mock_celery_task.apply_async.assert_called()
         self.assertEqual("4c1761d8-c0cd-4068-a997-ccab60592943", str(self.job.outputs.first().background_task_id))
 
     def test_outputs_should_run_in_specific_queue_if_provided_in_job_meta(self):

--- a/lumberjack/tests/jobs/test_managers.py
+++ b/lumberjack/tests/jobs/test_managers.py
@@ -58,7 +58,7 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         self.assertEqual(2, self.job.outputs.count())
         self.assertEqual(Output.objects.filter(job_id=self.job.id).first(), self.job.outputs.first())
 
-    @mock.patch("apps.jobs.managers.app.control")
+    @mock.patch("apps.jobs.models.app.control")
     def test_stop_should_revoke_background_task(self, mock_celery_control):
         self.manager.stop()
 
@@ -66,7 +66,7 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         mock_celery_control.revoke.assert_called()
 
     @mock.patch("apps.jobs.tasks.VideoTranscoderTask")
-    @mock.patch("apps.jobs.managers.app.control")
+    @mock.patch("apps.jobs.models.app.control")
     def test_restart_job_should_stop_running_task_and_start_again(self, mock_celery_control, mock_celery_task):
         mock_celery_task.apply_async().task_id = "4c1761d8-c0cd-4068-a997-ccab60592943"
         self.manager.restart()
@@ -81,7 +81,7 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         self.job.meta_data = json.dumps({"queue": "priority"})
         self.job.save()
         self.create_output(job=self.job)
-        self.manager.start_tasks()
+        self.manager.start()
 
         mock_celery_task.apply_async.assert_called_with(
             kwargs={"job_id": self.job.id, "output_id": self.job.outputs.last().id}, queue="priority"
@@ -93,7 +93,7 @@ class TestVideoTranscodeManager(TestCase, Mixin):
         self.job.meta_data = None
         self.job.save()
         self.create_output(job=self.job)
-        self.manager.start_tasks()
+        self.manager.start()
 
         mock_celery_task.apply_async.assert_called_with(
             kwargs={"job_id": self.job.id, "output_id": self.job.outputs.last().id}, queue="transcoding"

--- a/lumberjack/tests/jobs/test_tasks.py
+++ b/lumberjack/tests/jobs/test_tasks.py
@@ -67,7 +67,7 @@ class TestVideoTranscoder(Mixin, TestCase):
         self.assertEqual(self.job.progress, 20)
 
     @mock.patch("apps.jobs.runnables.Manager", **{"return_value.run.side_effect": FFMpegException()})
-    @mock.patch("apps.jobs.managers.app.GroupResult")
+    @mock.patch("apps.jobs.models.app.GroupResult")
     def test_task_should_be_stopped_in_case_of_exception(self, mock_group_result, mock_ffmpeg_manager):
         task_mock = mock.MagicMock()
         mock_group_result.restore.return_value = [task_mock]
@@ -77,7 +77,7 @@ class TestVideoTranscoder(Mixin, TestCase):
         self.assertEqual(self.video_transcoder.job.status, Job.ERROR)
 
     @mock.patch("apps.jobs.runnables.Manager", **{"return_value.run.side_effect": SoftTimeLimitExceeded()})
-    @mock.patch("apps.jobs.managers.app.GroupResult")
+    @mock.patch("apps.jobs.models.app.GroupResult")
     def test_task_should_stop_ffmpeg_process_in_case_of_soft_time_limit_exception(
         self, mock_group_result, mock_ffmpeg_manager
     ):


### PR DESCRIPTION
- Removed celery group because with the group we cannot stop or restart individual tasks. So if we want to restart a single resolution we cannot do that.
- Instead for each resolution we can start separate tasks and stop them separately.


No of test cases - Existing