### PR TITLE
Fix other outputs not stopped in case of error in single output

### DIFF
--- a/lumberjack/apps/jobs/runnables.py
+++ b/lumberjack/apps/jobs/runnables.py
@@ -130,10 +130,9 @@ class VideoTranscoderRunnable(LumberjackRunnable):
         self.output.save()
 
     def stop_job(self):
-        group_tasks = app.GroupResult.restore(str(self.job.background_task_id))
-        for task in group_tasks:
-            if task.id != self.task_id:  # Skip killing current task as it is going to be stopped anyway.
-                task.revoke(terminate=True, signal="SIGUSR1")
+        for output in self.job.outputs.all():
+            if output.id != self.output.id:  # Skip killing current task as it is going to be stopped anyway.
+                output.stop_task()
 
     def is_job_status_error(self):
         return Job.objects.get(id=self.job.id).status == Job.ERROR


### PR DESCRIPTION
- This was degraded in 1ca2869. Previously we were using the celery group but in 1ca2869 we started using individual tasks,  so we need to kill other tasks. 