### PR TITLE
Limit task prefetching to 1

### DIFF
--- a/lumberjack/lumberjack/settings.py
+++ b/lumberjack/lumberjack/settings.py
@@ -150,6 +150,7 @@ CELERY_TIMEZONE = "Asia/Kolkata"
 CELERY_TASK_ROUTES = {
     "apps.jobs.tasks.VideoTranscoderTask": {"queue": "transcoding"},
 }
+CELERYD_PREFETCH_MULTIPLIER = 1
 
 REST_FRAMEWORK = {"DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination", "PAGE_SIZE": 100}
 


### PR DESCRIPTION
- By default, a worker will prefetch up to 4 tasks. The issue here is if the first worker prefetches more than 1 task then those prefetched tasks will be executed only by that worker even if another worker is free. If that first worker is not free then those prefetched tasks will be waiting until it is free.
- So if we limit prefetching to 1 then the workers will prefetch only 1 task so tasks will be provided to whichever worker is free.