### PR TITLE
Support output folder url in job settings

### DIFF
--- a/lumberjack/apps/ffmpeg/command_generator.py
+++ b/lumberjack/apps/ffmpeg/command_generator.py
@@ -3,8 +3,8 @@ from collections import OrderedDict
 
 from django.conf import settings
 
-from apps.ffmpeg.utils import mkdir
-from .inputs import get_input_path, generate_file_name_from_format
+from apps.ffmpeg.utils import mkdir, generate_file_name_from_format
+from .inputs import get_input_path
 
 
 class CommandGenerator(object):

--- a/lumberjack/apps/ffmpeg/command_generator.py
+++ b/lumberjack/apps/ffmpeg/command_generator.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from django.conf import settings
 
 from apps.ffmpeg.utils import mkdir
-from .inputs import get_input_path
+from .inputs import get_input_path, generate_file_name_from_format
 
 
 class CommandGenerator(object):
@@ -51,7 +51,11 @@ class CommandGenerator(object):
 
     @property
     def output_path(self):
-        return "{}/{}/{}".format(self.local_path, self.options.get("output")["name"], self.options.get("file_name"))
+        if self.options.get("file_name"):
+            file_name = self.options.get("file_name")
+        else:
+            file_name = generate_file_name_from_format(self.options.get("format"))
+        return "{}/{}/{}".format(self.local_path, self.options.get("output")["name"], file_name)
 
     @property
     def media_options(self):

--- a/lumberjack/apps/ffmpeg/command_generator.py
+++ b/lumberjack/apps/ffmpeg/command_generator.py
@@ -51,10 +51,10 @@ class CommandGenerator(object):
 
     @property
     def output_path(self):
-        if self.options.get("file_name"):
-            file_name = self.options.get("file_name")
-        else:
+        file_name = self.options.get("file_name")
+        if not file_name:
             file_name = generate_file_name_from_format(self.options.get("format"))
+
         return "{}/{}/{}".format(self.local_path, self.options.get("output")["name"], file_name)
 
     @property

--- a/lumberjack/apps/ffmpeg/inputs.py
+++ b/lumberjack/apps/ffmpeg/inputs.py
@@ -16,6 +16,13 @@ def get_input_path(path):
     return path
 
 
+def generate_file_name_from_format(format):
+    if format.lower() == "mp4":
+        return "video.mp4"
+    elif format.lower() == "hls":
+        return "video.m3u8"
+
+
 class InputPath(abc.ABC):
     def __init__(self, source):
         self.source = source

--- a/lumberjack/apps/ffmpeg/inputs.py
+++ b/lumberjack/apps/ffmpeg/inputs.py
@@ -16,13 +16,6 @@ def get_input_path(path):
     return path
 
 
-def generate_file_name_from_format(format):
-    if format.lower() == "mp4":
-        return "video.mp4"
-    elif format.lower() == "hls":
-        return "video.m3u8"
-
-
 class InputPath(abc.ABC):
     def __init__(self, source):
         self.source = source

--- a/lumberjack/apps/ffmpeg/utils.py
+++ b/lumberjack/apps/ffmpeg/utils.py
@@ -7,3 +7,10 @@ def mkdir(dirname: str) -> None:
         os.makedirs(dirname)
     except OSError as exc:
         logging.info(exc)
+
+
+def generate_file_name_from_format(format):
+    if format.lower() == "mp4":
+        return "video.mp4"
+    elif format.lower() == "hls":
+        return "video.m3u8"

--- a/lumberjack/tests/ffmpeg/test_command_generator.py
+++ b/lumberjack/tests/ffmpeg/test_command_generator.py
@@ -75,6 +75,11 @@ class TestCommandGenerator(SimpleTestCase):
         output_path = "tests/ffmpeg/data/1232/360p/video.m3u8"
         self.assertEqual(output_path, self.command_generator.output_path)
 
+    @override_settings(TRANSCODED_VIDEOS_PATH="tests/ffmpeg/data")
+    def test_output_path_should_generate_filename_for_relative_path(self):
+        output_path = "tests/ffmpeg/data/1232/360p/"
+        self.assertEqual(output_path + "video.m3u8", self.command_generator.output_path)
+
 
 class TestHLSKeyInfoFile(SimpleTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
- For transcoding, we need to provide input and output URL. Right now output URL should be a file location. For ex: s3://bucket_name/folder/file.m3u8
- But if we want to support transcoding to multiple formats (HLS and Dash) then the output URL should be folder path (s3://bucket_name/folder/). So that for each format, different folders will be created in that relative path. 
- This commit adds support for output URL as a folder location.