### PR TITLE
Use FFMpeg for clearkey encryption of HLS

### DIFF
--- a/lumberjack/apps/executors/transcoder.py
+++ b/lumberjack/apps/executors/transcoder.py
@@ -28,11 +28,11 @@ class FFMpegTranscoder(PolitelyWaitOnFinishExecutor):
     STDOUT = subprocess.PIPE
     STDERR = subprocess.STDOUT
 
-    def __init__(self, config, progress_callback=None):
+    def __init__(self, config, progress_callback=None, command=None):
         super().__init__()
         self.config = config
         self.progress_observer = progress_callback
-        self.command = CommandGenerator(config).generate()
+        self.command = command or CommandGenerator(config).generate()
         self.event_source = None
 
     def pre_start(self):


### PR DESCRIPTION
- We are using Shaka packager for clear key encryption of HLS. But ShakaPackager uses Sample-AES to encrypt which is not widely supported in all browsers.
- So we are using FFMpeg itself to package for clear key encryption of HLS